### PR TITLE
Release: polkadot-stable2509

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -47,7 +47,7 @@ parts:
   polkadot-parachain:
     plugin: rust
     source: https://github.com/paritytech/polkadot-sdk.git
-    source-tag: polkadot-stable2506-2
+    source-tag: polkadot-stable2509
     source-depth: 1
     build-packages:
       - build-essential


### PR DESCRIPTION
Release for https://github.com/paritytech/polkadot-sdk/releases/tag/polkadot-stable2509